### PR TITLE
Fix EXP pin aliases for Spider.

### DIFF
--- a/Release_2_1/Klipper_Config/K2_fysetc_spider_+_btt_motor_expander_config-250mm_x_250mm_x_250mm_build.cfg
+++ b/Release_2_1/Klipper_Config/K2_fysetc_spider_+_btt_motor_expander_config-250mm_x_250mm_x_250mm_build.cfg
@@ -27,18 +27,18 @@ restart_method: command
 [board_pins]
 aliases:
     # EXP2 header
-    EXP1_10=<5V>, EXP1_9=<GND>,
-    EXP1_8=PD1,   EXP1_7=PD0,
-    EXP1_6=PC12,  EXP1_5=PC10,
-    EXP1_4=PD2,   EXP1_3=PC11,
-    EXP1_2=PA8,   EXP1_1=PC9,
+    EXP1_1=<5V>, EXP1_2=<GND>,
+    EXP1_3=PD1,   EXP1_4=PD0,
+    EXP1_5=PC12,  EXP1_6=PC10,
+    EXP1_7=PD2,   EXP1_8=PC11,
+    EXP1_9=PA8,   EXP1_10=PC9,
 
     # EXP1 header
-    EXP2_10=<5V>, EXP2_9=<GND>,
-    EXP2_8=<RST>, EXP2_7=PB10,
-    EXP2_6=PA7,   EXP2_5=PC7,
-    EXP2_4=PA4,   EXP2_3=PC6,
-    EXP2_2=PA5,   EXP2_1=PA6
+    EXP2_1=<5V>, EXP2_2=<GND>,
+    EXP2_3=<RST>, EXP2_4=PB10,
+    EXP2_5=PA7,   EXP2_6=PC7,
+    EXP2_7=PA4,   EXP2_8=PC6,
+    EXP2_9=PA5,   EXP2_10=PA6
 
 #virtual sdcard settings
 [virtual_sdcard]


### PR DESCRIPTION
The pin aliases in the config are incorrect and cause the motor to heat up. These pin aliases worked for me, with the extruder connected to M1 I was able to buzz the extruder and make it extrude.