### PR TITLE
Add pullup to probe pin for Spider.

### DIFF
--- a/Release_2_1/Klipper_Config/K2_fysetc_spider_+_btt_motor_expander_config-250mm_x_250mm_x_250mm_build.cfg
+++ b/Release_2_1/Klipper_Config/K2_fysetc_spider_+_btt_motor_expander_config-250mm_x_250mm_x_250mm_build.cfg
@@ -294,7 +294,7 @@ enable_force_move: true
 # Dockable Probe
 [dockable_probe]
 # connected to E1 (Y-Max Port) Endstop on SPIDER
-pin: PA2
+pin: ^PA2
 x_offset: -12.5 # offset for microswitch x direction off nozzle
 y_offset: 16 # offset for microswitch y direction off nozzle
 z_offset: 8 # offset for microswitch in z height - this is a starting point only


### PR DESCRIPTION
Without the pull-up, `QUERY_PROBE` reports `open` even without the probe attached.